### PR TITLE
Add Native iOS support for AlertBanner

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "nightly" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "nightly" ]
   workflow_call:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,14 +18,14 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-      # - name: Publish to MavenCentral
-      #   run: ./gradlew publishToMavenCentral --no-configuration-cache
-      #   env:
-      #     ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-      #     ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-      #     ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-      #     ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-      #     ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      - name: Publish to MavenCentral
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
       - name: Build XCFramework
         run: ./gradlew :alert-banner:assembleAlertBannerReleaseXCFramework --no-configuration-cache
       - name: Zip XCFramework

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,4 +32,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${{ github.event.release.tag_name }}" AlertBanner.xcframework.zip
+      - name: Update Package.swift with checksum
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHECKSUM=$(swift package compute-checksum AlertBanner.xcframework.zip)
+          TAG="${{ github.event.release.tag_name }}"
+          sed -i '' "s|url: \".*AlertBanner.xcframework.zip\"|url: \"https://github.com/mofeejegi/compose-alert-banner/releases/download/$TAG/AlertBanner.xcframework.zip\"|" Package.swift
+          sed -i '' "s|checksum: \".*\"|checksum: \"$CHECKSUM\"|" Package.swift
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          git commit -m "Update Package.swift for $TAG"
+          git push origin HEAD:nightly
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      - name: Build XCFramework
+        run: ./gradlew :alert-banner:assembleAlertBannerReleaseXCFramework --no-configuration-cache
+      - name: Zip XCFramework
+        run: |
+          cd alert-banner/build/XCFrameworks/release
+          zip -r "$GITHUB_WORKSPACE/AlertBanner.xcframework.zip" AlertBanner.xcframework
+      - name: Upload XCFramework to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" AlertBanner.xcframework.zip
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish
 on:
   release:
     types: [released, prereleased]
+
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Release build and publish
@@ -14,14 +18,14 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-      - name: Publish to MavenCentral
-        run: ./gradlew publishToMavenCentral --no-configuration-cache
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+      # - name: Publish to MavenCentral
+      #   run: ./gradlew publishToMavenCentral --no-configuration-cache
+      #   env:
+      #     ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      #     ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      #     ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      #     ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      #     ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
       - name: Build XCFramework
         run: ./gradlew :alert-banner:assembleAlertBannerReleaseXCFramework --no-configuration-cache
       - name: Zip XCFramework

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "AlertBanner",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "AlertBanner",
+            targets: ["AlertBanner"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "AlertBanner",
+            url: "https://github.com/mofeejegi/compose-alert-banner/releases/download/VERSION_PLACEHOLDER/AlertBanner.xcframework.zip",
+            checksum: "CHECKSUM_PLACEHOLDER"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Author](https://img.shields.io/badge/author-mofeejegi-gray.svg?logo=github)](https://github.com/mofeejegi) 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24) 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)
 
 A **simple**, **customizable**, and **modern** library for displaying alert banners in your Jetpack Compose, Compose Multiplatform, and native iOS (Swift) applications. Easily integrate and adapt to suit any style or use case—from error notifications to informational messages!
 
@@ -61,7 +61,7 @@ Here's how it looks:
 
 ## Installation
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)
 
 Compose Alert Banner is available as a Gradle dependency on `mavenCentral`. You can add it to your project by including the following in your `build.gradle.kts` file:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Author](https://img.shields.io/badge/author-mofeejegi-gray.svg?logo=github)](https://github.com/mofeejegi) 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24) 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)
 
 A **simple**, **customizable**, and **modern** library for displaying alert banners in your Jetpack Compose, Compose Multiplatform, and native iOS (Swift) applications. Easily integrate and adapt to suit any style or use case—from error notifications to informational messages!
 
@@ -61,7 +61,7 @@ Here's how it looks:
 
 ## Installation
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha02)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)
 
 Compose Alert Banner is available as a Gradle dependency on `mavenCentral`. You can add it to your project by including the following in your `build.gradle.kts` file:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Author](https://img.shields.io/badge/author-mofeejegi-gray.svg?logo=github)](https://github.com/mofeejegi) 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24) 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.0.0-rc01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.0.0-rc01)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)
 
-A **simple**, **customizable**, and **modern** library for displaying alert banners in your Jetpack Compose and Compose Multiplatform applications. Easily integrate and adapt to suit any style or use case—from error notifications to informational messages!
+A **simple**, **customizable**, and **modern** library for displaying alert banners in your Jetpack Compose, Compose Multiplatform, and native iOS (Swift) applications. Easily integrate and adapt to suit any style or use case—from error notifications to informational messages!
 
 <img src="docs/readme_images/compose%20banner.png" alt="Banner">
 
@@ -17,7 +17,8 @@ A **simple**, **customizable**, and **modern** library for displaying alert bann
 - [Features](#features)
 - [Samples](#samples)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Compose Usage](#compose-usage)
+- [iOS (Swift) Usage](#ios-swift-usage)
 - [Configuration & Customization](#configuration--customization)
 - [Contributing](#contributing)
 - [License](#license)
@@ -60,7 +61,7 @@ Here's how it looks:
 
 ## Installation
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.0.0-rc01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.0.0-rc01)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha01)
 
 Compose Alert Banner is available as a Gradle dependency on `mavenCentral`. You can add it to your project by including the following in your `build.gradle.kts` file:
 
@@ -75,7 +76,7 @@ dependencies {
 ```
 Replace `<latest-version>` with the current release version available in the [Releases](https://github.com/mofeejegi/compose-alert-banner/releases) section.
 
-## Usage
+## Compose Usage
 
 Integrating the alert banner into your Compose application is straightforward. Below is a simple example to get you started:
 
@@ -101,6 +102,93 @@ fun MyApp() {
     }
 }
 ```
+
+## iOS (Swift) Usage
+
+Compose Alert Banner can be used directly in native Swift iOS projects via Swift Package Manager — no Compose or Kotlin knowledge required.
+
+### Installation (Swift Package Manager)
+
+In Xcode, go to **File > Add Package Dependencies** and enter:
+
+```
+https://github.com/mofeejegi/compose-alert-banner
+```
+
+Select the latest version from the [Releases](https://github.com/mofeejegi/compose-alert-banner/releases) page.
+
+### SwiftUI / UIKit (Window Overlay)
+
+Call `attach()` once at the root of your app. Then call `showSuccess` or `showError` from anywhere.
+
+```swift
+import AlertBanner
+
+@main
+struct MyApp: App {
+    let alertBanner = AlertBannerIOS.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onAppear { alertBanner.attach() }
+        }
+    }
+}
+
+struct ContentView: View {
+    let alertBanner = AlertBannerIOS.shared
+
+    var body: some View {
+        VStack {
+            Button("Show Success") {
+                alertBanner.showSuccess(message: "Saved successfully!")
+            }
+            Button("Show Error") {
+                alertBanner.showError(message: "Something went wrong")
+            }
+        }
+    }
+}
+```
+
+### UIKit (Child View Controller)
+
+Call `install(on:)` once on your root view controller. Then call `showSuccess` or `showError` from anywhere.
+
+```swift
+import AlertBanner
+
+class RootViewController: UIViewController {
+    let alertBanner = AlertBannerIOS.shared
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        alertBanner.install(on: self)
+    }
+
+    @objc func onSave() {
+        alertBanner.showSuccess(message: "Saved successfully!")
+    }
+
+    @objc func onError() {
+        alertBanner.showError(message: "Something went wrong")
+    }
+}
+```
+
+### API Reference
+
+| Method                   | Description                                                                                    |
+|--------------------------|------------------------------------------------------------------------------------------------|
+| `AlertBannerIOS.shared`  | Singleton instance - use from anywhere                                                         |
+| `.attach()`              | Creates a window overlay. Call once at the root                                                |
+| `.install(on:)`          | Adds as a child view controller. Call once on the root view controller                         |
+| `.showSuccess(message:)` | Shows a success alert banner                                                                   |
+| `.showError(message:)`   | Shows an error alert banner                                                                    |
+| `.configure(darkTheme:)` | Sets dark/light theme. Call before `attach()` or `install(on:)`. Defaults to system appearance |
+| `.detach()`              | Removes the overlay window                                                                     |
+| `.uninstall()`           | Removes the child view controller                                                              |
 
 ## Configuration & Customization
 

--- a/alert-banner/build.gradle.kts
+++ b/alert-banner/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
 }
 
 group = "com.mofeejegi.alert"
-version = "1.1.0-alpha01"
+version = "1.1.0-alpha02"
 
 mavenPublishing {
     publishToMavenCentral()

--- a/alert-banner/build.gradle.kts
+++ b/alert-banner/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -18,9 +19,14 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
+    val xcf = XCFramework("AlertBanner")
+    listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "AlertBanner"
+            isStatic = true
+            xcf.add(this)
+        }
+    }
 
     wasmJs {
         browser()
@@ -89,7 +95,7 @@ dependencies {
 }
 
 group = "com.mofeejegi.alert"
-version = "1.0.0-rc01"
+version = "1.1.0-alpha01"
 
 mavenPublishing {
     publishToMavenCentral()

--- a/alert-banner/build.gradle.kts
+++ b/alert-banner/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
 }
 
 group = "com.mofeejegi.alert"
-version = "1.1.0-alpha02"
+version = "1.1.0-alpha03"
 
 mavenPublishing {
     publishToMavenCentral()

--- a/alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt
+++ b/alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt
@@ -75,6 +75,10 @@ internal fun AlertBannerView(
                 dismissOnClickOutside = false,
             )
         ) {
+            DisposableEffect(Unit) {
+                onDispose { onAlertAreaChanged?.invoke(0f) }
+            }
+
             LazyColumn(
                 Modifier
                     .systemBarsPadding()

--- a/alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt
+++ b/alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -59,6 +61,7 @@ internal fun AlertBannerView(
     vm: AlertBannerViewModel,
     textStyle: TextStyle,
     onAlertColor: Color,
+    onAlertAreaChanged: ((bottom: Float) -> Unit)? = null,
 ) {
     val viewState by vm.viewState.collectAsState()
     val alertsToDisplay = viewState.orderedAlerts
@@ -76,7 +79,13 @@ internal fun AlertBannerView(
                 Modifier
                     .systemBarsPadding()
                     .fillMaxWidth()
-                    .wrapContentHeight(),
+                    .wrapContentHeight()
+                    .onGloballyPositioned { coordinates ->
+                        onAlertAreaChanged?.let { callback ->
+                            val bottom = coordinates.positionInWindow().y + coordinates.size.height
+                            callback(bottom)
+                        }
+                    },
                 userScrollEnabled = false,
             ) {
                 items(

--- a/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
+++ b/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
@@ -2,8 +2,6 @@ package com.mofeejegi.alert
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeUIViewController
@@ -96,10 +94,6 @@ object AlertBannerIOS {
             val vm = viewModel { AlertBannerViewModel() }
             val manager = remember { AlertManager(vm::processEvent) }
             LaunchedEffect(manager) { alertManager = manager }
-
-            // Reset touch area when all alerts are dismissed
-            val viewState by vm.viewState.collectAsState()
-            if (viewState.orderedAlerts.isEmpty()) alertAreaBottom = 0.0
 
             AlertTheme(darkTheme = darkTheme ?: isSystemInDarkTheme()) {
                 AlertBannerView(

--- a/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
+++ b/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
@@ -26,6 +26,7 @@ import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowLevelNormal
+import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIWindowScene
 import platform.UIKit.addChildViewController
 import platform.UIKit.didMoveToParentViewController
@@ -71,7 +72,7 @@ object AlertBannerIOS {
     private var darkTheme: Boolean? = null
     private var alertManager: AlertManager? = null
     private var overlayWindow: UIWindow? = null
-    private var installedVC: UIViewController? = null
+    private var installedBannerVC: UIViewController? = null
 
     // Actual bottom Y of the alert area in points, measured from Compose via onGloballyPositioned.
     // When 0, no alerts are showing and all touches pass through.
@@ -135,7 +136,10 @@ object AlertBannerIOS {
         if (overlayWindow != null) return
 
         val scene = UIApplication.sharedApplication.connectedScenes
-            .firstOrNull { it is UIWindowScene } as? UIWindowScene ?: return
+            .firstOrNull {
+                it is UIWindowScene &&
+                    it.activationState == UISceneActivationStateForegroundActive
+            } as? UIWindowScene ?: return
 
         val window = PassthroughWindow(
             windowScene = scene,
@@ -156,6 +160,8 @@ object AlertBannerIOS {
         overlayWindow?.setHidden(true)
         overlayWindow?.rootViewController = null
         overlayWindow = null
+        alertManager = null
+        alertAreaBottom = 0.0
     }
 
     // -- UIKit child view controller --
@@ -167,10 +173,10 @@ object AlertBannerIOS {
      */
     @OptIn(ExperimentalForeignApi::class)
     fun install(on: UIViewController) {
-        if (installedVC != null) return
+        if (installedBannerVC != null) return
 
         val bannerVC = makeViewController()
-        installedVC = bannerVC
+        installedBannerVC = bannerVC
 
         val container = PassthroughView(
             frame = on.view.bounds,
@@ -201,11 +207,13 @@ object AlertBannerIOS {
      * Removes the alert banner from its parent view controller.
      */
     fun uninstall() {
-        installedVC?.let { bannerVC ->
+        installedBannerVC?.let { bannerVC ->
             bannerVC.willMoveToParentViewController(null)
             bannerVC.view.superview?.removeFromSuperview()
             bannerVC.removeFromParentViewController()
-            installedVC = null
+            installedBannerVC = null
+            alertManager = null
+            alertAreaBottom = 0.0
         }
     }
 

--- a/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
+++ b/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
@@ -1,0 +1,254 @@
+package com.mofeejegi.alert
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeUIViewController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.mofeejegi.alert.ui.bannertype.AlertBannerType
+import com.mofeejegi.alert.ui.composable.AlertBannerView
+import com.mofeejegi.alert.ui.manager.AlertManager
+import com.mofeejegi.alert.ui.state.AlertBannerViewModel
+import com.mofeejegi.alert.ui.theme.AlertTheme
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGRect
+import platform.UIKit.UIApplication
+import platform.UIKit.UIColor
+import platform.UIKit.UIEvent
+import platform.UIKit.UIView
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowLevelNormal
+import platform.UIKit.UIWindowScene
+import platform.UIKit.addChildViewController
+import platform.UIKit.didMoveToParentViewController
+import platform.UIKit.removeFromParentViewController
+import platform.UIKit.willMoveToParentViewController
+
+/**
+ * iOS entry point for the AlertBanner library.
+ *
+ * ## SwiftUI / UIKit (window overlay)
+ * ```swift
+ * let alertBanner = AlertBannerIOS.shared
+ *
+ * // Optionally configure before attaching
+ * alertBanner.configure(darkTheme: true)
+ *
+ * // Attach once at the root of your app
+ * alertBanner.attach()
+ *
+ * // Show alerts from anywhere
+ * alertBanner.showSuccess(message: "Saved!")
+ * alertBanner.showError(message: "Something went wrong")
+ * ```
+ *
+ * ## UIKit (child view controller)
+ * ```swift
+ * class RootViewController: UIViewController {
+ *     let alertBanner = AlertBannerIOS.shared
+ *
+ *     override func viewDidLoad() {
+ *         super.viewDidLoad()
+ *         // Install once on the root view controller
+ *         alertBanner.install(on: self)
+ *     }
+ *
+ *     @objc func onSave() {
+ *         alertBanner.showSuccess(message: "Saved!")
+ *     }
+ * }
+ * ```
+ */
+object AlertBannerIOS {
+    private var darkTheme: Boolean? = null
+    private var alertManager: AlertManager? = null
+    private var overlayWindow: UIWindow? = null
+    private var installedVC: UIViewController? = null
+
+    // Actual bottom Y of the alert area in points, measured from Compose via onGloballyPositioned.
+    // When 0, no alerts are showing and all touches pass through.
+    private var alertAreaBottom = 0.0
+
+    /**
+     * Configures the alert banner theme. Call before [attach] or [install].
+     *
+     * @param darkTheme If true, uses dark theme. If false, uses light theme.
+     *                  If not called, the system appearance is used.
+     */
+    fun configure(darkTheme: Boolean) {
+        this.darkTheme = darkTheme
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun makeViewController(): UIViewController {
+        val vc = ComposeUIViewController(
+            configure = { opaque = false }
+        ) {
+            val vm = viewModel { AlertBannerViewModel() }
+            val manager = remember { AlertManager(vm::processEvent) }
+            LaunchedEffect(manager) { alertManager = manager }
+
+            // Reset touch area when all alerts are dismissed
+            val viewState by vm.viewState.collectAsState()
+            if (viewState.orderedAlerts.isEmpty()) alertAreaBottom = 0.0
+
+            AlertTheme(darkTheme = darkTheme ?: isSystemInDarkTheme()) {
+                AlertBannerView(
+                    vm = vm,
+                    textStyle = AlertTheme.typography.bodySmall,
+                    onAlertColor = AlertTheme.colorScheme.tone1,
+                    onAlertAreaChanged = { bottomPx ->
+                        val density = platform.UIKit.UIScreen.mainScreen.scale
+                        alertAreaBottom = bottomPx.toDouble() / density
+                    },
+                )
+            }
+        }
+        vc.view.setBackgroundColor(UIColor.clearColor)
+        return vc
+    }
+
+    fun showSuccess(message: String) {
+        alertManager?.show(message, AlertBannerType.Success)
+    }
+
+    fun showError(message: String) {
+        alertManager?.show(message, AlertBannerType.Error)
+    }
+
+    // -- Window overlay (works with SwiftUI and UIKit) --
+
+    /**
+     * Creates a transparent overlay window above the app's content and attaches
+     * the alert banner to it. Works with both SwiftUI and UIKit.
+     * Call once at the root of your app.
+     */
+    fun attach() {
+        if (overlayWindow != null) return
+
+        val scene = UIApplication.sharedApplication.connectedScenes
+            .firstOrNull { it is UIWindowScene } as? UIWindowScene ?: return
+
+        val window = PassthroughWindow(
+            windowScene = scene,
+            alertAreaHeight = { alertAreaBottom },
+        )
+        window.windowLevel = UIWindowLevelNormal + 1
+        window.rootViewController = makeViewController()
+        window.setBackgroundColor(UIColor.clearColor)
+        window.setHidden(false)
+
+        overlayWindow = window
+    }
+
+    /**
+     * Removes the overlay window.
+     */
+    fun detach() {
+        overlayWindow?.setHidden(true)
+        overlayWindow?.rootViewController = null
+        overlayWindow = null
+    }
+
+    // -- UIKit child view controller --
+
+    /**
+     * Installs the alert banner as a child overlay on the given parent UIViewController.
+     * The banner view is pinned to all edges of the parent's view.
+     * Call once on the root view controller.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    fun install(on: UIViewController) {
+        if (installedVC != null) return
+
+        val bannerVC = makeViewController()
+        installedVC = bannerVC
+
+        val container = PassthroughView(
+            frame = on.view.bounds,
+            alertAreaHeight = { alertAreaBottom },
+        )
+        container.setBackgroundColor(UIColor.clearColor)
+
+        on.addChildViewController(bannerVC)
+        container.addSubview(bannerVC.view)
+        on.view.addSubview(container)
+
+        container.setTranslatesAutoresizingMaskIntoConstraints(false)
+        container.topAnchor.constraintEqualToAnchor(on.view.topAnchor).setActive(true)
+        container.leadingAnchor.constraintEqualToAnchor(on.view.leadingAnchor).setActive(true)
+        container.trailingAnchor.constraintEqualToAnchor(on.view.trailingAnchor).setActive(true)
+        container.bottomAnchor.constraintEqualToAnchor(on.view.bottomAnchor).setActive(true)
+
+        bannerVC.view.setTranslatesAutoresizingMaskIntoConstraints(false)
+        bannerVC.view.topAnchor.constraintEqualToAnchor(container.topAnchor).setActive(true)
+        bannerVC.view.leadingAnchor.constraintEqualToAnchor(container.leadingAnchor).setActive(true)
+        bannerVC.view.trailingAnchor.constraintEqualToAnchor(container.trailingAnchor).setActive(true)
+        bannerVC.view.bottomAnchor.constraintEqualToAnchor(container.bottomAnchor).setActive(true)
+
+        bannerVC.didMoveToParentViewController(on)
+    }
+
+    /**
+     * Removes the alert banner from its parent view controller.
+     */
+    fun uninstall() {
+        installedVC?.let { bannerVC ->
+            bannerVC.willMoveToParentViewController(null)
+            bannerVC.view.superview?.removeFromSuperview()
+            bannerVC.removeFromParentViewController()
+            installedVC = null
+        }
+    }
+
+}
+
+/**
+ * A UIWindow that only intercepts touches in the alert banner area at the top
+ * of the screen. All other touches pass through to the app below.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private class PassthroughWindow(
+    windowScene: UIWindowScene,
+    private val alertAreaHeight: () -> Double,
+) : UIWindow(windowScene = windowScene) {
+
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
+        val height = alertAreaHeight()
+        if (height <= 0.0) return null
+
+        val y = point.useContents { y }
+        if (y > height) return null
+
+        return super.hitTest(point, withEvent)
+    }
+}
+
+/**
+ * A UIView that only intercepts touches in the alert banner area at the top.
+ * All other touches pass through to views below.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private class PassthroughView(
+    frame: CValue<CGRect>,
+    private val alertAreaHeight: () -> Double,
+) : UIView(frame = frame) {
+
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
+        val height = alertAreaHeight()
+        if (height <= 0.0) return null
+
+        val y = point.useContents { y }
+        if (y > height) return null
+
+        return super.hitTest(point, withEvent)
+    }
+}


### PR DESCRIPTION
This pull request introduces native iOS (Swift) support to the alert banner library, allowing the component to be used directly in SwiftUI and UIKit applications, in addition to Jetpack Compose and Compose Multiplatform. The update also improves the Compose API by exposing the alert banner area for better touch handling, and updates documentation and build configuration to reflect these new capabilities.

**iOS Support & API Enhancements:**

* Added a new `AlertBannerIOS` API for native Swift integration, supporting both overlay window and child view controller modes, with passthrough touch handling outside the banner area. This enables seamless use in SwiftUI and UIKit apps without Compose or Kotlin knowledge. (`alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt`)
* Updated the Compose alert banner to expose a callback (`onAlertAreaChanged`) for reporting the banner's bottom position, enabling correct passthrough touch behavior on iOS overlays. (`alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt`) [[1]](diffhunk://#diff-a4de2a5a885529220652d4ccac98039bb224006646e850807d09fe1727c05454R64) [[2]](diffhunk://#diff-a4de2a5a885529220652d4ccac98039bb224006646e850807d09fe1727c05454L79-R88)

**Build & Versioning:**

* Updated the multiplatform build to produce a static iOS `XCFramework` named `AlertBanner`, and bumped the library version to `1.1.0-alpha01` for the new release. (`alert-banner/build.gradle.kts`) [[1]](diffhunk://#diff-1a15c2441e10b53784d14019e8575e66f085d470550e4529b054e66e4c530900L21-R29) [[2]](diffhunk://#diff-1a15c2441e10b53784d14019e8575e66f085d470550e4529b054e66e4c530900L92-R98)

**Documentation:**

* Expanded the `README.md` to document iOS installation and usage, including Swift Package Manager instructions and SwiftUI/UIKit code examples, and updated all references and badges to the new version. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R64) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R79) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R192)

**Dependency Updates:**

* Added missing imports for Compose layout measurement to support the new iOS touch passthrough logic. (`alert-banner/src/commonMain/kotlin/com/mofeejegi/alert/ui/composable/AlertBannerView.kt`)