### PR TITLE
Fix Native iOS Scene Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Author](https://img.shields.io/badge/author-mofeejegi-gray.svg?logo=github)](https://github.com/mofeejegi) 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=24) 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha04)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha04)
 
 A **simple**, **customizable**, and **modern** library for displaying alert banners in your Jetpack Compose, Compose Multiplatform, and native iOS (Swift) applications. Easily integrate and adapt to suit any style or use case—from error notifications to informational messages!
 
@@ -61,7 +61,7 @@ Here's how it looks:
 
 ## Installation
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha03)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha04)](https://central.sonatype.com/artifact/com.mofeejegi.alert/alert-banner-compose/1.1.0-alpha04)
 
 Compose Alert Banner is available as a Gradle dependency on `mavenCentral`. You can add it to your project by including the following in your `build.gradle.kts` file:
 

--- a/alert-banner/build.gradle.kts
+++ b/alert-banner/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
 }
 
 group = "com.mofeejegi.alert"
-version = "1.1.0-alpha03"
+version = "1.1.0-alpha04"
 
 mavenPublishing {
     publishToMavenCentral()

--- a/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
+++ b/alert-banner/src/iosMain/kotlin/com/mofeejegi/alert/AlertBannerIOS.kt
@@ -24,7 +24,6 @@ import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowLevelNormal
-import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIWindowScene
 import platform.UIKit.addChildViewController
 import platform.UIKit.didMoveToParentViewController
@@ -130,10 +129,7 @@ object AlertBannerIOS {
         if (overlayWindow != null) return
 
         val scene = UIApplication.sharedApplication.connectedScenes
-            .firstOrNull {
-                it is UIWindowScene &&
-                    it.activationState == UISceneActivationStateForegroundActive
-            } as? UIWindowScene ?: return
+            .firstOrNull { it is UIWindowScene } as? UIWindowScene ?: return
 
         val window = PassthroughWindow(
             windowScene = scene,


### PR DESCRIPTION
This pull request updates the project version to `1.1.0-alpha04` and makes a minor code simplification for iOS scene selection. The most significant changes are the version bump across project files and a small refactor in the iOS implementation.

**Version bump:**

* Updated Maven Central badge and installation instructions in `README.md` to reflect the new version `1.1.0-alpha04`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64)
* Updated the `version` property in `alert-banner/build.gradle.kts` to `1.1.0-alpha04`.

**iOS code maintenance:**

* Removed the unused import of `UISceneActivationStateForegroundActive` in `AlertBannerIOS.kt`.
* Simplified the logic for selecting the active `UIWindowScene` by removing the check for `activationState == UISceneActivationStateForegroundActive` in `AlertBannerIOS.kt`.